### PR TITLE
Fix typo in run_single.py

### DIFF
--- a/src/data/run_single.py
+++ b/src/data/run_single.py
@@ -95,7 +95,7 @@ def run_single_experiment(config_path: str, tag_override: str = None):
         **cfg.training.scheduler
     )
 
-    print(f"\nLoss Funciton Config: \n\t{cfg.training.loss_fn}")
+    print(f"\nLoss Function Config: \n\t{cfg.training.loss_fn}")
     loss_fn = get_loss_function(cfg.training.loss_fn)
     trainer = Trainer(
         model=model,


### PR DESCRIPTION
## Summary
- fix a misspelling in `run_single.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fae9f7c5483218a6263d3f64763f1